### PR TITLE
fix fullscreen for Chrome and up recording resolution

### DIFF
--- a/css/alexcam.css
+++ b/css/alexcam.css
@@ -25,10 +25,13 @@
 #video-container {
   display: block;
   height: 480px;
-  left: calc((100% - 640px) / 2);
-  position: absolute;
-  top: 5em;
   width: 640px;
+  margin: auto;
+  position: relative;
+}
+#video-container:-webkit-full-screen {
+  width: 100%;
+  height: 100%;
 }
 
 #disclaimer {

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
         </div>
         <div id="video-container"></div>
 
-        <div id="disclaimer">Disclaimer: Only works in Firefox and Chrome currently.  Fullscreen only works properly in Firefox.</div>
+        <div id="disclaimer">Disclaimer: Only works in Firefox and Chrome currently.</div>
         <!-- github ribbon -->
         <a href="https://github.com/marumari/alexcam"><img id="github-ribbon" src="images/github-ribbon.png" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
         <script

--- a/js/alexcam.js
+++ b/js/alexcam.js
@@ -60,6 +60,8 @@ function recordVideo() {
   // create a new MediaStreamRecorder
   mirror.recorder = new MediaStreamRecorder(mirror.stream);
   mirror.recorder.mimeType = 'video/webm';
+  mirror.recorder.width = 640;
+  mirror.recorder.height = 480;
 
   // when it's finished recording a segment, add the video to the container
   mirror.recorder.ondataavailable = function (blob) {
@@ -194,4 +196,3 @@ $(document).ready(function () {
   // load the default video stream on and request permissions, on page load
   initializeMirror();
 });
-


### PR DESCRIPTION
The CSS change fixes fullscreen support for Chrome, the main issue was: http://stackoverflow.com/questions/32618762/requestfullscreen-in-chrome-image-remains-small.

I also set the recording resolution at 480p, as the default seems lower and when doing a delay, it would playback at a lower resolution than live video which was a bummer. Ideally we'd detect the resolution of the camera, but this seems like an improvement as many laptop webcams are 480p, and I don't see a huge harm in recording at 480p even if the webcam is lower res.
